### PR TITLE
Optimize travis build speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -A128m -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -A512m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests
+        cabal configure --enable-tests --ghc-options="-j +RTS -A128m -n2m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -A128m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -A256m -s -RTS"
+        cabal configure --enable-tests --ghc-options="+RTS -A512m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="+RTS -A512m -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -A128m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -A128m -n2m -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -A512m -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -A256m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ install:
       cabal)
         cabal --version
         travis_retry cabal update
-        cabal install --only-dependencies --enable-tests
-        cabal install hlint
+        cabal install -j --only-dependencies --enable-tests
+        cabal install -j hlint
         ;;
     esac
 


### PR DESCRIPTION
Using the following resources https://rybczak.net/2016/03/26/how-to-reduce-compilation-times-of-haskell-projects/, we've been able to accomplish build times as low as 8 minutes.

The main change was adding ghc options to the cabal configuration that would build multi core, and increase the allocation area for the garbage collector. Currently this commit sets the allocation area for the garbage collector to 128mb (which by default is 512k), and omits the division of allocation area. 

### Issues 

I did not have success with increasing the allocation area to 256, or 512mb (even though we should have 4GB memory based on [travis virtual environment table](https://docs.travis-ci.com/user/ci-environment/), also unclear how much memory is free up to the cabal config point). Travis build seems crash to when that was the case, also when trying to divide the allocation area. 

```
Preprocessing library crux-0.1.0.0...
[ 1 of 26] Compiling Crux.Util        ( Crux/Util.hs, dist/build/Crux/Util.o )
[ 2 of 26] Compiling Crux.Text        ( Crux/Text.hs, dist/build/Crux/Text.o )
[ 3 of 26] Compiling Crux.IORef       ( Crux/IORef.hs, dist/build/Crux/IORef.o )
[ 4 of 26] Compiling Crux.Pos         ( Crux/Pos.hs, dist/build/Crux/Pos.o )
[ 5 of 26] Compiling Crux.Prelude     ( Crux/Prelude.hs, dist/build/Crux/Prelude.o )
[ 6 of 26] Compiling Crux.ModuleName  ( Crux/ModuleName.hs, dist/build/Crux/ModuleName.o )
[ 7 of 26] Compiling Crux.TypeVar     ( Crux/TypeVar.hs, dist/build/Crux/TypeVar.o )
/home/travis/build.sh: line 45:  3283 Killed                  cabal build
Preprocessing library crux-0.1.0.0...
[12 of 26] Compiling Crux.Error       ( Crux/Error.hs, dist/build/Crux/Error.o )
[13 of 26] Compiling Crux.Typecheck.Monad ( Crux/Typecheck/Monad.hs, dist/build/Crux/Typecheck/Monad.o )
[14 of 26] Compiling Crux.SymbolTable ( Crux/SymbolTable.hs, dist/build/Crux/SymbolTable.o )
[15 of 26] Compiling Crux.AST         ( Crux/AST.hs, dist/build/Crux/AST.o )
/home/travis/build.sh: line 45:  3397 Killed                  cabal test
/home/travis/build.sh: line 50: dist/build/crux/crux: No such file or directory
```

### Differences

With the changes we decreased the number of data collections from `18652`
```
Gen  0     18652 colls, 18584 par   1489.378s  747.084s     0.0401s    0.5140s
```
to `166`
```
Gen  0       166 colls,   166 par   123.697s  61.977s     0.3734s    2.2157s
```

You may fully review the build log before the garbage collection tweaks [here](https://travis-ci.org/cruxlang/crux/builds/163360669) (38min) compared to the [latest](https://travis-ci.org/cruxlang/crux/builds/163375317) (8min);

![image](https://cloud.githubusercontent.com/assets/735039/18912947/2a3a0846-8553-11e6-8619-ac11b5c01557.png)

You'll find that in approximately 4 minutes, the `dist/build/crux/crux test` command will start running, which does take it's time. 
