### PR TITLE
Divide allocation area into chunks of the specified size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -A128m -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -A64m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -A64m -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -A64m -n2m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - |
     case "$BUILD" in
       cabal)
-        cabal configure --enable-tests --ghc-options="-j +RTS -A64m -n2m -s -RTS"
+        cabal configure --enable-tests --ghc-options="-j +RTS -A84m -n2m -s -RTS"
         cabal build
         cabal test 
         dist/build/crux/crux test


### PR DESCRIPTION
Experimented with many variations of garbage collector allocation sizes, and added division of allocation area.

Travis, kills the process when the garbage collector allocation size is greater than `109m`, I've also notice that setting it to `84m` or `109m` did not have a significant speed change to warrant keeping it at `109m`, because even at `109m` travis does attempt to kill the build process but the build did not fail, if you try `110m` or greater you're guaranteed to fail the build.

This change seems to shave an extra 3 minutes on the build time, so we maybe looking at 6 to 7 minute builds.


> -nsize

>[Default: 0, Example: -n4m] When set to a non-zero value, this option divides the allocation area (-A value) into chunks of the specified size. During execution, when a processor exhausts its current chunk, it is given another chunk from the pool until the pool is exhausted, at which point a collection is triggered.

>This option is only useful when running in parallel (-N2 or greater). It allows the processor cores to make better use of the available allocation area, even when cores are allocating at different rates. Without -n, each core gets a fixed-size allocation area specified by the -A, and the first core to exhaust its allocation area triggers a GC across all the cores. This can result in a collection happening when the allocation areas of some cores are only partially full, so the purpose of the -n is to allow cores that are allocating faster to get more of the allocation area. This means less frequent GC, leading a lower GC overhead for the same heap size.

>This is particularly useful in conjunction with larger -A values, for example -A64m -n4m is a useful combination on larger core counts (8+).

source: https://rybczak.net/2016/03/26/how-to-reduce-compilation-times-of-haskell-projects/